### PR TITLE
use prefetch_related for improve queries.

### DIFF
--- a/votes/views.py
+++ b/votes/views.py
@@ -56,7 +56,7 @@ def ingresos_2021(request):
 
     persons = CompiledPerson.objects.filter(
         person__elections=election,
-    ).order_by('-ingreso_total')
+    ).prefetch_related("person").order_by('-ingreso_total')
 
     if region:
         persons = persons.filter(person__strPostulaDistrito=region)
@@ -76,7 +76,7 @@ def ingresos_2021_json(request):
     election = make_context()[1]
     persons = CompiledPerson.objects.filter(
         person__elections=election,
-    ).order_by('-ingreso_total')
+    ).prefetch_related("person").order_by('-ingreso_total')
 
     data = []
     for candidate in persons:
@@ -105,7 +105,7 @@ def sentencias_2021(request):
     context, election = make_context()
     persons = CompiledPerson.objects.filter(
         person__elections=election,
-    ).order_by('-sentencias_total')
+    ).prefetch_related("person").order_by('-sentencias_total')
 
     if region and region == "TODAS":
         persons = persons.exclude(person__strPostulaDistrito="NoDefinida")
@@ -134,7 +134,7 @@ def sentencias_2021_json(request):
     election = make_context()[1]
     persons = CompiledPerson.objects.filter(
         person__elections=election,
-    ).order_by('-sentencias_total')
+    ).prefetch_related("person").order_by('-sentencias_total')
 
     data = []
     for candidate in persons:
@@ -157,7 +157,7 @@ def bienes_2021(request):
 
     persons = CompiledPerson.objects.filter(
         person__elections=election
-    ).order_by('-total_muebles_inmuebles')
+    ).prefetch_related("person").order_by('-total_muebles_inmuebles')
 
     if region and region == "TODAS":
         persons = persons.exclude(person__strPostulaDistrito="NoDefinida")
@@ -180,7 +180,7 @@ def bienes_2021_json(request):
     election = make_context()[1]
     persons = CompiledPerson.objects.filter(
         person__elections=election
-    ).order_by('-total_muebles_inmuebles')
+    ).prefetch_related("person").order_by('-total_muebles_inmuebles')
 
     data = []
     for candidate in persons:


### PR DESCRIPTION
Se usa `prefetch_related` para mejorar las consultas a base de datos en velocidad y en veces que golpea el servidor de base de datos.